### PR TITLE
Add a second configuration for running a local version of the docker-compose environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a docker configuration setup to build the full CRN stack. This includes:
 - [bids-core](https://github.com/poldracklab/bids-core)
-- [crn-app](https://github.com/poldracklab/crn_appmongodb.com - MongoDB Official Site‎)
+- [crn-app](https://github.com/poldracklab/crn_app)
 - [crn-server](https://github.com/poldracklab/crn_server)
 - [mongodb](https://www.mongodb.com/)
 - [nginx](https://nginx.org/)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,36 @@
+# docker compose versions
+version: '2'
+
+# shared volumes
+volumes:
+  project:
+
+services:
+  # web app bundle build
+  app:
+    image: poldracklab/crn_app:${CRN_APP_TAG}
+    command: gulp
+    volumes:
+      - ../crn_app:/srv/crn-app
+      - project:/srv/crn-app/dist
+
+  # crn core (bids-core)
+  core:
+    volumes:
+      - ../bids-core:/srv/bids-core
+      - ${PERSISTENT_DIR}/bids-core/persistent/data:/srv/bids-core/persistent/data
+
+  # crn node server
+  server:
+    volumes:
+      - ../crn_server:/srv/crn-server
+      - ./server/client.config.js:/srv/crn-server/client.config.js:rw
+      - ${PERSISTENT_DIR}/bids-core/persistent/data:/srv/bids-core/persistent/data
+      - ${PERSISTENT_DIR}/crn-server/persistent:/srv/crn-server/persistent
+
+  # nginx - static file serving and service proxy
+  nginx:
+    ports:
+      - "9876:80"
+      - "8110:8110"
+      - "8443:443"


### PR DESCRIPTION
Example usage for running local git branches via docker:
`docker-compose -f docker-compose.yml -f docker-compose.dev.yml up`

This assumes you've checked out the other repos in the same parent directory as the crn_deploy repo.


Also includes on small fix for the readme format.