### PR TITLE
Store node_modules in a docker volume specific to each environment.

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
 
   # crn node server
   server:
-    command: bash -c "yarn install && node /srv/crn-server/index.js"
+    command: bash -c "yarn install --mutex file:/srv/server_node_modules/.mutex && node /srv/crn-server/index.js"
     volumes:
       - ../openneuro/server:/srv/crn-server
       - server_node_modules:/srv/crn-server/node_modules
@@ -34,6 +34,7 @@ services:
       - ${PERSISTENT_DIR}/crn-server/persistent:/srv/crn-server/persistent
 
   worker:
+    command: bash -c "yarn install --mutex file:/srv/server_node_modules/.mutex && node /srv/crn-server/worker.js"
     volumes:
       - ../openneuro/server:/srv/crn-server
       - server_node_modules:/srv/crn-server/node_modules

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,6 +4,8 @@ version: '2'
 # shared volumes
 volumes:
   project:
+  server_node_modules:
+  app_node_modules:
 
 services:
   # web app bundle build
@@ -12,6 +14,7 @@ services:
     command: bash -c "yarn install && gulp --env=dev"
     volumes:
       - ../openneuro/app:/srv/crn-app
+      - app_node_modules:/srv/crn-app/node_modules
       - project:/srv/crn-app/dist
 
   # crn core (bids-core)
@@ -22,8 +25,10 @@ services:
 
   # crn node server
   server:
+    command: bash -c "yarn install && node /srv/crn-server/index.js"
     volumes:
       - ../openneuro/server:/srv/crn-server
+      - server_node_modules:/srv/crn-server/node_modules
       - ./server/client.config.js:/srv/crn-server/client.config.js:rw
       - ${PERSISTENT_DIR}/bids-core/persistent/data:/srv/bids-core/persistent/data
       - ${PERSISTENT_DIR}/crn-server/persistent:/srv/crn-server/persistent
@@ -31,6 +36,7 @@ services:
   worker:
     volumes:
       - ../openneuro/server:/srv/crn-server
+      - server_node_modules:/srv/crn-server/node_modules
       - ./server/client.config.js:/srv/crn-server/client.config.js:rw
       - ${PERSISTENT_DIR}/bids-core/persistent/data:/srv/bids-core/persistent/data
       - ${PERSISTENT_DIR}/crn-server/persistent:/srv/crn-server/persistent

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,7 @@ version: '2'
 volumes:
   project:
   server_node_modules:
+  worker_node_modules:
   app_node_modules:
 
 services:
@@ -25,7 +26,7 @@ services:
 
   # crn node server
   server:
-    command: bash -c "yarn install --mutex file:/srv/server_node_modules/.mutex && node /srv/crn-server/index.js"
+    command: bash -c "yarn install && node /srv/crn-server/index.js"
     volumes:
       - ../openneuro/server:/srv/crn-server
       - server_node_modules:/srv/crn-server/node_modules
@@ -34,10 +35,10 @@ services:
       - ${PERSISTENT_DIR}/crn-server/persistent:/srv/crn-server/persistent
 
   worker:
-    command: bash -c "yarn install --mutex file:/srv/server_node_modules/.mutex && node /srv/crn-server/worker.js"
+    command: bash -c "yarn install && node /srv/crn-server/worker.js"
     volumes:
       - ../openneuro/server:/srv/crn-server
-      - server_node_modules:/srv/crn-server/node_modules
+      - worker_node_modules:/srv/crn-server/node_modules
       - ./server/client.config.js:/srv/crn-server/client.config.js:rw
       - ${PERSISTENT_DIR}/bids-core/persistent/data:/srv/bids-core/persistent/data
       - ${PERSISTENT_DIR}/crn-server/persistent:/srv/crn-server/persistent


### PR DESCRIPTION
This lets a developer run node commands in their environment without breaking node_modules in the containers.

The main downside to this is you have to run stuff like 'yarn add new-dependency' with docker-compose exec to test it in the container. Initial creation no longer depends on the node_modules state though, so easier to get going.