### PR TITLE
Pass the git repo into the dev container to expose git values in dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,11 +12,11 @@ services:
     image: openneuro/app:${CRN_APP_TAG}
     command: sh -c "yarn install --pure-lockfile && yarn start"
     volumes:
-      - ../openneuro/app:/srv/crn-app
+      - ../openneuro:/srv
       - yarn_cache:/root/.cache
-      - project:/srv/crn-app/dist
+      - project:/srv/app/dist
     tmpfs:
-      - /srv/crn-app/node_modules:exec
+      - /srv/app/node_modules:exec
 
   # crn core (bids-core)
   core:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   app:
     image: openneuro/app:${CRN_APP_TAG}
     volumes:
-      - project:/srv/crn-app/dist
+      - project:/srv/app/dist
     env_file: ./config.env
 
   # crn core (bids-core)

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,7 +45,7 @@ server {
     }
 
     # crn-web app
-    root /srv/crn-app/dist;
+    root /srv/app/dist;
     location /index.html {
         add_header Cache-Control 'max-age=0; public';
     }

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -30,7 +30,7 @@ server {
     }
 
     # crn-web app
-    root /srv/crn-app/dist;
+    root /srv/app/dist;
     location / {
     	proxy_pass http://app:9876;
 	proxy_http_version 1.1;


### PR DESCRIPTION
This is so webpack-dev-server can access git information. Required for OpenNeuroOrg/openneuro#233